### PR TITLE
🐛 stub active_support/tagged_logging

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,5 @@
 require "kettle/soup/cover/config"
 
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/lib/active_support"
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-Since version 2.0.0, the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,32 +3,8 @@ PATH
   specs:
     activesupport-tagged_logging (2.0.0)
       activesupport (>= 5.2)
-      activesupport-broadcast_logger (~> 2.0, >= 2.0.0)
-      activesupport-logger (~> 2.0, >= 2.0.0)
-      logger (~> 1.6, >= 1.6.1)
-      mutex_m (~> 0.1)
-      rdoc (~> 6.8, >= 6.8.1)
-      stringio (>= 0.0.2)
-      version_gem (~> 1.1, >= 1.1.4)
-
-PATH
-  remote: /Users/pboling/src/my/activesupport-broadcast_logger
-  specs:
-    activesupport-broadcast_logger (2.0.1)
-      activesupport (>= 5.2)
+      activesupport-broadcast_logger (~> 2.0, >= 2.0.1)
       activesupport-logger (~> 2.0, >= 2.0.1)
-      logger (~> 1.6, >= 1.6.1)
-      mutex_m (~> 0.1)
-      rdoc (~> 6.8, >= 6.8.1)
-      stringio (>= 0.0.2)
-      version_gem (~> 1.1, >= 1.1.4)
-
-PATH
-  remote: /Users/pboling/src/my/activesupport-logger
-  specs:
-    activesupport-logger (2.0.1)
-      activesupport (>= 5.2)
-      backports (~> 3.25, >= 3.25.0)
       logger (~> 1.6, >= 1.6.1)
       mutex_m (~> 0.1)
       rdoc (~> 6.8, >= 6.8.1)
@@ -51,6 +27,22 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    activesupport-broadcast_logger (2.0.1)
+      activesupport (>= 5.2)
+      activesupport-logger (~> 2.0, >= 2.0.1)
+      logger (~> 1.6, >= 1.6.1)
+      mutex_m (~> 0.1)
+      rdoc (~> 6.8, >= 6.8.1)
+      stringio (>= 0.0.2)
+      version_gem (~> 1.1, >= 1.1.4)
+    activesupport-logger (2.0.1)
+      activesupport (>= 5.2)
+      backports (~> 3.25, >= 3.25.0)
+      logger (~> 1.6, >= 1.6.1)
+      mutex_m (~> 0.1)
+      rdoc (~> 6.8, >= 6.8.1)
+      stringio (>= 0.0.2)
+      version_gem (~> 1.1, >= 1.1.4)
     ansi (1.5.0)
     appraisal (2.5.0)
       bundler
@@ -252,8 +244,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport-broadcast_logger!
-  activesupport-logger!
   activesupport-tagged_logging!
   appraisal (~> 2.5)
   byebug (>= 11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,30 @@ PATH
       stringio (>= 0.0.2)
       version_gem (~> 1.1, >= 1.1.4)
 
+PATH
+  remote: /Users/pboling/src/my/activesupport-broadcast_logger
+  specs:
+    activesupport-broadcast_logger (2.0.1)
+      activesupport (>= 5.2)
+      activesupport-logger (~> 2.0, >= 2.0.1)
+      logger (~> 1.6, >= 1.6.1)
+      mutex_m (~> 0.1)
+      rdoc (~> 6.8, >= 6.8.1)
+      stringio (>= 0.0.2)
+      version_gem (~> 1.1, >= 1.1.4)
+
+PATH
+  remote: /Users/pboling/src/my/activesupport-logger
+  specs:
+    activesupport-logger (2.0.1)
+      activesupport (>= 5.2)
+      backports (~> 3.25, >= 3.25.0)
+      logger (~> 1.6, >= 1.6.1)
+      mutex_m (~> 0.1)
+      rdoc (~> 6.8, >= 6.8.1)
+      stringio (>= 0.0.2)
+      version_gem (~> 1.1, >= 1.1.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -27,22 +51,6 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    activesupport-broadcast_logger (2.0.0)
-      activesupport (>= 5.2)
-      activesupport-logger (~> 2.0, >= 2.0.0)
-      logger (~> 1.6, >= 1.6.1)
-      mutex_m (~> 0.1)
-      rdoc (~> 6.8, >= 6.8.1)
-      stringio (>= 0.0.2)
-      version_gem (~> 1.1, >= 1.1.4)
-    activesupport-logger (2.0.0)
-      activesupport (>= 5.2)
-      backports (~> 3.25, >= 3.25.0)
-      logger (~> 1.6, >= 1.6.1)
-      mutex_m (~> 0.1)
-      rdoc (~> 6.8, >= 6.8.1)
-      stringio (>= 0.0.2)
-      version_gem (~> 1.1, >= 1.1.4)
     ansi (1.5.0)
     appraisal (2.5.0)
       bundler
@@ -103,7 +111,7 @@ GEM
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
     logger (1.6.1)
-    minitest (5.25.1)
+    minitest (5.25.2)
     mutex_m (0.3.0)
     ostruct (0.6.1)
     parallel (1.26.3)
@@ -244,6 +252,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport-broadcast_logger!
+  activesupport-logger!
   activesupport-tagged_logging!
   appraisal (~> 2.5)
   byebug (>= 11)

--- a/activesupport-tagged_logging.gemspec
+++ b/activesupport-tagged_logging.gemspec
@@ -55,8 +55,8 @@ Gem::Specification.new do |spec|
 
   # Runtime Dependencies
   spec.add_dependency("activesupport", ">= 5.2")
-  spec.add_dependency("activesupport-broadcast_logger", "~> 2.0", ">= 2.0.0")
-  spec.add_dependency("activesupport-logger", "~> 2.0", ">= 2.0.0")
+  spec.add_dependency("activesupport-broadcast_logger", "~> 2.0", ">= 2.0.1")
+  spec.add_dependency("activesupport-logger", "~> 2.0", ">= 2.0.1")
   spec.add_dependency("version_gem", "~> 1.1", ">= 1.1.4")
 
   # Documentation

--- a/lib/active_support/tagged_logging.rb
+++ b/lib/active_support/tagged_logging.rb
@@ -1,0 +1,4 @@
+# This is a stub
+# It will prevent vanilla ActiveSupport from loading its own broken logger tooling.
+# Instead, we'll load the fixed replacement logging tooling from this library!
+require_relative "../activesupport-tagged_logging"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# Loading "active_support" normally here ensures this library will work,
+#   even if loaded after the vanilla ActiveSupport.
+# Unfortunately, it also results in 0% code coverage, because this gem gets loaded too early.
+# require "active_support"
+# require "active_support/tagged_logging"
+
 # External Deps
 require "minitest"
 require "test-unit"


### PR DESCRIPTION
- This library is intended to replace active_support/tagged_logging, but it can't if active_support/tagged_logging has already been loaded
- stubbing the file to load this library's tagged_logging, instead of vanilla, hijacks Rails internals to work for us